### PR TITLE
Fix documentation and comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ query := "What is your name?"
 name, err := ui.Ask(query, &input.Options{
     Default: "tcnksm",
     Required: true,
-	Loop:     true,
+    Loop:     true,
 })
 ```
 

--- a/input.go
+++ b/input.go
@@ -12,7 +12,7 @@ http://github.com/tcnksm/go-input
   name, err := ui.Ask(query, &input.Options{
       Default: "tcnksm",
       Required: true,
-	  Loop:     true,
+      Loop:     true,
   })
 */
 package input
@@ -35,7 +35,7 @@ var (
 )
 
 var (
-	// Errs are error retunrned by input functions.
+	// Errs are error returned by input functions.
 	// It's useful for handling error from outside of this function.
 	ErrEmpty      = errors.New("default value is not provided but input is empty")
 	ErrNotNumber  = errors.New("input must be number")
@@ -101,7 +101,7 @@ type Options struct {
 // ValidateFunc is function to validate user input
 type ValidateFunc func(string) error
 
-// validateFunc returns ValidateFunc. If it's specifed by
+// validateFunc returns ValidateFunc. If it's specified by
 // user it returns it. If not returns default function.
 func (o *Options) validateFunc() ValidateFunc {
 	if o.ValidateFunc == nil {
@@ -117,7 +117,7 @@ func defaultValidateFunc(input string) error {
 	return nil
 }
 
-// maskOpts returns maskOptions from given the Options.
+// readOpts returns readOptions from given the Options.
 func (o *Options) readOpts() *readOptions {
 	var mask bool
 	var maskVal string

--- a/read_unix.go
+++ b/read_unix.go
@@ -1,4 +1,5 @@
 // +build linux darwin freebsd
+
 package input
 
 import (

--- a/read_windows.go
+++ b/read_windows.go
@@ -1,4 +1,5 @@
 // +build windows
+
 package input
 
 import (
@@ -6,7 +7,7 @@ import (
 	"syscall"
 )
 
-// Magic constant from MSDN to control whether charactesr read are
+// Magic constant from MSDN to control whether characters read are
 // repeated back on the console.
 //
 // http://msdn.microsoft.com/en-us/library/windows/desktop/ms686033(v=vs.85).aspx
@@ -14,7 +15,7 @@ const ENABLE_ECHO_INPUT = 0x0004
 
 // rawRead reads file with raw mode (without prompting to terminal).
 //
-// For this windows version of rawRead(). I refered the codes on
+// For this windows version of rawRead(). I referred the codes on
 // hashicorp/vault/helper and cloudfoundry/cli/terminal
 func (i *UI) rawRead(f *os.File) (string, error) {
 

--- a/select.go
+++ b/select.go
@@ -26,11 +26,11 @@ func (i *UI) Select(query string, list []string, opts *Options) (string, error) 
 			}
 		}
 
-		// DefaultVal is set but does'nt exist in list
+		// DefaultVal is set but doesn't exist in list
 		if defaultIndex == -1 {
 			// This error message is not for user
 			// Should be found while development
-			return "", fmt.Errorf("opt.Default is specied but item does not exst in list")
+			return "", fmt.Errorf("opt.Default is specified but item does not exist in list")
 		}
 	}
 
@@ -110,7 +110,7 @@ func (i *UI) Select(query string, list []string, opts *Options) (string, error) 
 			continue
 		}
 
-		// validate input by custom fuction
+		// validate input by custom function
 		validate := opts.validateFunc()
 		if err := validate(line); err != nil {
 			if !opts.Loop {


### PR DESCRIPTION
- Correct misspelling
- Correct wrong function name and return type
- Fix indentation
- Insert new line after build tag comment for 'go vet'
