### PR TITLE
fix windows compat

### DIFF
--- a/read.go
+++ b/read.go
@@ -46,7 +46,9 @@ func (i *UI) read(opts *readOptions) (string, error) {
 				resultErr = fmt.Errorf("failed to read the input: %s", err)
 			}
 
-			resultStr = strings.TrimSuffix(line, "\r\n")
+			resultStr = strings.TrimSuffix(line, LINE_SEP)
+			// brute force for the moment
+			resultStr = strings.TrimSuffix(line, "\n")
 		}
 	}()
 

--- a/read.go
+++ b/read.go
@@ -46,7 +46,7 @@ func (i *UI) read(opts *readOptions) (string, error) {
 				resultErr = fmt.Errorf("failed to read the input: %s", err)
 			}
 
-			resultStr = strings.TrimSuffix(line, "\n")
+			resultStr = strings.TrimSuffix(line, "\r\n")
 		}
 	}()
 

--- a/read.go
+++ b/read.go
@@ -46,7 +46,7 @@ func (i *UI) read(opts *readOptions) (string, error) {
 				resultErr = fmt.Errorf("failed to read the input: %s", err)
 			}
 
-			resultStr = strings.TrimSuffix(line, LINE_SEP)
+			resultStr = strings.TrimSuffix(line, LineSep)
 			// brute force for the moment
 			resultStr = strings.TrimSuffix(line, "\n")
 		}

--- a/read_unix.go
+++ b/read_unix.go
@@ -9,6 +9,9 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
+// LINE_SEP is the separator for windows or unix systems
+const LINE_SEP = "\n"
+
 // rawRead reads file with raw mode (without prompting to terminal).
 func (i *UI) rawRead(f *os.File) (string, error) {
 

--- a/read_unix.go
+++ b/read_unix.go
@@ -9,8 +9,8 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-// LINE_SEP is the separator for windows or unix systems
-const LINE_SEP = "\n"
+// LineSep is the separator for windows or unix systems
+const LineSep = "\n"
 
 // rawRead reads file with raw mode (without prompting to terminal).
 func (i *UI) rawRead(f *os.File) (string, error) {

--- a/read_windows.go
+++ b/read_windows.go
@@ -7,8 +7,8 @@ import (
 	"syscall"
 )
 
-// LINE_SEP is the separator for windows or unix systems
-const LINE_SEP = "\r\n"
+// LineSep is the separator for windows or unix systems
+const LineSep = "\r\n"
 
 // Magic constant from MSDN to control whether characters read are
 // repeated back on the console.

--- a/read_windows.go
+++ b/read_windows.go
@@ -7,6 +7,8 @@ import (
 	"syscall"
 )
 
+const LINE_SEP = "\r\n"
+
 // Magic constant from MSDN to control whether characters read are
 // repeated back on the console.
 //

--- a/read_windows.go
+++ b/read_windows.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 )
 
+// LINE_SEP is the separator for windows or unix systems
 const LINE_SEP = "\r\n"
 
 // Magic constant from MSDN to control whether characters read are


### PR DESCRIPTION
exact same issue as presented here: https://github.com/tj/go-prompt/commit/0d6b6628b949eeb2e85fd0ab97152656cd3d2d0e

as an example, the current behavior on windows with a select option gives the following error when choosing 2:

> Enter a number (Default is 1): 2
> "2\r" is not a valid input. Answer by a number.