### PR TITLE
slight bug in the resultStr trimming, should be sequentially trimming

### DIFF
--- a/read.go
+++ b/read.go
@@ -48,7 +48,7 @@ func (i *UI) read(opts *readOptions) (string, error) {
 
 			resultStr = strings.TrimSuffix(line, LineSep)
 			// brute force for the moment
-			resultStr = strings.TrimSuffix(line, "\n")
+			resultStr = strings.TrimSuffix(resultStr, "\n")
 		}
 	}()
 


### PR DESCRIPTION
Very minor bug, previously was first trimming based on the LineSep, however overwriting it by the second trim as was still referencing the line itself. Proper behavior is to successively trim the resultStr so it can handle the windows-specific line ending (if there) then also trim any `\n` that exists.