### PR TITLE
Avoid adding newlines to output by default

### DIFF
--- a/ask.go
+++ b/ask.go
@@ -62,7 +62,7 @@ func (i *UI) Ask(query string, opts *Options) (string, error) {
 				break
 			}
 
-			fmt.Fprintf(i.Writer, "Input must not be empty.\n\n")
+			fmt.Fprintf(i.Writer, "Input must not be empty.")
 			continue
 		}
 
@@ -74,7 +74,7 @@ func (i *UI) Ask(query string, opts *Options) (string, error) {
 				break
 			}
 
-			fmt.Fprintf(i.Writer, "Failed to validate input string: %s\n\n", err)
+			fmt.Fprintf(i.Writer, "Failed to validate input string: %s", err)
 			continue
 		}
 

--- a/select.go
+++ b/select.go
@@ -87,7 +87,7 @@ func (i *UI) Select(query string, list []string, opts *Options) (string, error) 
 				break
 			}
 
-			fmt.Fprintf(i.Writer, "Input must not be empty. Answer by a number.\n\n")
+			fmt.Fprintf(i.Writer, "Input must not be empty. Answer by a number.")
 			continue
 		}
 
@@ -100,7 +100,7 @@ func (i *UI) Select(query string, list []string, opts *Options) (string, error) 
 			}
 
 			fmt.Fprintf(i.Writer,
-				"%q is not a valid input. Answer by a number.\n\n", line)
+				"%q is not a valid input. Answer by a number.", line)
 			continue
 		}
 
@@ -112,7 +112,7 @@ func (i *UI) Select(query string, list []string, opts *Options) (string, error) 
 			}
 
 			fmt.Fprintf(i.Writer,
-				"%q is not a valid choice. Choose a number from 1 to %d.\n\n",
+				"%q is not a valid choice. Choose a number from 1 to %d.",
 				line, len(list))
 			continue
 		}
@@ -125,7 +125,7 @@ func (i *UI) Select(query string, list []string, opts *Options) (string, error) 
 				break
 			}
 
-			fmt.Fprintf(i.Writer, "Failed to validate input string: %s\n\n", err)
+			fmt.Fprintf(i.Writer, "Failed to validate input string: %s", err)
 			continue
 		}
 


### PR DESCRIPTION
When newlines are hardcoded in the library, all user's of this library are forced into that ui-design choice without a way to modify that behaviour. This way, user's can opt to add newlines as they wish ... in their own tools.

For example, in the example below ... I would like not two have two empty lines after "Failed to validate". And even if I did, I'd prefer to have to add them myself for flexibility.

**Before:**

```console
$ cli-tool-that-does-something
What is your token uuid?
Enter a value: afdsf
Failed to validate input string: afdsf


Enter a value: 2343242
```

**After:**

```console
$ cli-tool-that-does-something
What is your token uuid?
Enter a value: afdsf
Failed to validate input string: afdsf
Enter a value: 2343242
```

I took the liberty to remove other newlines.