### PR TITLE
Fix stuble issue on Windows

### DIFF
--- a/read.go
+++ b/read.go
@@ -46,7 +46,8 @@ func (i *UI) read(opts *readOptions) (string, error) {
 				resultErr = fmt.Errorf("failed to read the input: %s", err)
 			}
 
-			resultStr = strings.TrimSuffix(line, LineSep)
+			resultStr = strings.Trim(line, LineSep)
+			resultStr = strings.TrimSuffix(resultStr, "\n")
 		}
 	}()
 

--- a/read.go
+++ b/read.go
@@ -47,8 +47,6 @@ func (i *UI) read(opts *readOptions) (string, error) {
 			}
 
 			resultStr = strings.TrimSuffix(line, LineSep)
-			// brute force for the moment
-			resultStr = strings.TrimSuffix(line, "\n")
 		}
 	}()
 

--- a/read_windows.go
+++ b/read_windows.go
@@ -37,7 +37,7 @@ func (i *UI) rawRead(f *os.File) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	buffer := i.rawReadLine(stdinHandle)
+	buffer := i.rawReadline(stdinHandle)
 	resetFunc()
 	return buffer, nil
 }

--- a/read_windows.go
+++ b/read_windows.go
@@ -23,23 +23,16 @@ const ENABLE_ECHO_INPUT = 0x0004
 func (i *UI) rawRead(f *os.File) (string, error) {
 
 	// In windows, Handle can be used to examine or modify the system resource.
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms724457(v=vs.85).aspx
+	handle := syscall.Handle(f.Fd())
 
-	// Get the stdin handle
-	// Please see:
-	//   https://golang.org/pkg/syscall/?GOOS=windows#Handle
-	//   https://docs.microsoft.com/en-us/windows/console/getstdhandle
-	stdinHandle, stdinHandleErr := syscall.GetStdHandle(-10)
-	if stdinHandleErr != nil {
-		return "", stdinHandleErr
-	}
-
-	resetFunc, err := makeRaw(stdinHandle)
+	resetFunc, err := makeRaw(handle)
 	if err != nil {
 		return "", err
 	}
-	buffer := i.rawReadline(stdinHandle)
-	resetFunc()
-	return buffer, nil
+	defer resetFunc()
+
+	return i.rawReadline(f)
 }
 
 func makeRaw(console syscall.Handle) (func(), error) {


### PR DESCRIPTION
So `cmd.exe` supports piping and redirection. But when you do this the standard `syscall.Stdin` handle isn't _real_ anymore, and when ever involved in a call it'll throw an error. 

So you need to call into the Windows API to get the _proper_ `stdin` handle.

This patch does attempts to do this (as well as fix the Windows EOL stuff)