### PR TITLE
Fix a copy-paste error

### DIFF
--- a/read.go
+++ b/read.go
@@ -48,7 +48,7 @@ func (i *UI) read(opts *readOptions) (string, error) {
 
 			resultStr = strings.TrimSuffix(line, LineSep)
 			// brute force for the moment
-			resultStr = strings.TrimSuffix(line, "\n")
+			resultStr = strings.TrimSuffix(resultStr, "\n")
 		}
 	}()
 


### PR DESCRIPTION
The brute-force approach actually breaks the fix